### PR TITLE
Fix home slider to image reference 

### DIFF
--- a/theme/src/components/homeSlider.js
+++ b/theme/src/components/homeSlider.js
@@ -23,7 +23,7 @@ const renderItem = item => (
 const HomeSlider = ({ images }) => {
 	if (images && images.length > 0) {
 		const items = images.map(item => ({
-			original: item.url,
+			original: item.image,
 			title: item.title,
 			description: item.description,
 			path: item.path || '',


### PR DESCRIPTION
The home sliders images are not loading.

**Problem**
- The store was managing the asset theme URL, (asset and path information was required to be duplicated across the store and API. Ideally only the API should know about asset paths and this should be passed to the store.)
- The theme settings are stored on the API server in a static JSON file, Its complicated as these are complicated object set by placeholders that define the object structures. 

**Solution**
cezerin2-admin - https://github.com/Cezerin2/cezerin2-admin/pull/31
- Remove asset config reference
- Update image change to reflect asset url

cezerin2-store - https://github.com/Cezerin2/cezerin2-store/pull/33
- Update store_image slider to reference update image object

cezerin2 - https://github.com/Cezerin2/cezerin2/pull/163
- Return asset url with upload complete.
- Add changeProperties for theme settings to append and remove asset url.
- Remove unnecessary footer logo from theme settings.
