### PR TITLE
Fixed reference path failed when npm run build

### DIFF
--- a/theme/src/components/footer.js
+++ b/theme/src/components/footer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import { themeSettings, text } from '../lib/settings';
-import storeSettings from '../../../config/store';
+import storeSettings from '../../../../config/store';
 
 class FooterMenu extends React.Component {
 	constructor(props) {

--- a/theme/src/components/homeSlider.js
+++ b/theme/src/components/homeSlider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import ImageGallery from 'react-image-gallery';
 import { themeSettings } from '../lib/settings';
-import storeSettings from '../../../config/store';
+import storeSettings from '../../../../config/store';
 
 const renderItem = item => (
 	<div className="image-gallery-image">


### PR DESCRIPTION
I found error when running npm run build that can not found ../../../config/store path, by look at the path file it's at 
cezerin2-store/node_modules/theme/dist/components/homeSlider.js
cezerin2-store/node_modules/theme/dist/components/footer.js

Basically, it need ../../../../config/store

Which after changing this file then call `npm i --save ./theme` again then no problem found.
Note: I face error when run `npm i`

Ref: [Steps to reproduce](https://medium.com/@srihamat.a/ubuntu-18-04-how-to-install-cezerin-6067f409e0c)